### PR TITLE
Some Crashlytics Bugfixes

### DIFF
--- a/NotificationExtension/NotificationService.swift
+++ b/NotificationExtension/NotificationService.swift
@@ -68,11 +68,11 @@ class NotificationService: UNNotificationServiceExtension {
         // Called just before the extension will be terminated by the system.
         // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
         let defaults = CriptextDefaults()
-        if let activeAccount = defaults.activeAccount,
+        if let activeAccount = SharedDB.getActiveAccount(),
             let contentHandler = contentHandler,
             let bestAttemptContent =  bestAttemptContent {
             bestAttemptContent.categoryIdentifier = "GENERIC_PUSH"
-            bestAttemptContent.title = Utils.validateEmail(activeAccount) ? activeAccount : "\(activeAccount)\(Env.domain)"
+            bestAttemptContent.title = activeAccount.email
             bestAttemptContent.body = String.localize("You may have new emails")
             bestAttemptContent.badge = NSNumber(value: SharedDB.getUnreadCounters() + 1)
             contentHandler(bestAttemptContent)

--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Criptext</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ShareExtension/ShareViewController.swift
+++ b/ShareExtension/ShareViewController.swift
@@ -154,11 +154,9 @@ class ShareViewController: UIViewController {
     }
     
     func getAccount() {
-        let defaults = CriptextDefaults()
-        guard let accountId = defaults.activeAccount,
-            let account = SharedDB.getAccountById(accountId) else {
-                self.close()
-                return
+        guard let account = SharedDB.getActiveAccount() else {
+            self.close()
+            return
         }
         myAccount = account
     }

--- a/iOS-Email-Client.xcodeproj/project.pbxproj
+++ b/iOS-Email-Client.xcodeproj/project.pbxproj
@@ -3233,7 +3233,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.criptext.mail.ShareExtension;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = ShareExtension;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "ShareExtension/Extension-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -3263,7 +3263,7 @@
 				MARKETING_VERSION = 1.1.34;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.criptext.mail.ShareExtension;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = ShareExtension;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "ShareExtension/Extension-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -3294,7 +3294,7 @@
 				MARKETING_VERSION = 1.1.34;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.criptext.mail.support.ShareExtension;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = ShareExtension;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "ShareExtension/Extension-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/iOS-Email-Client/AsyncTasks/CIDSchemeHandler.swift
+++ b/iOS-Email-Client/AsyncTasks/CIDSchemeHandler.swift
@@ -22,7 +22,7 @@ class CIDSchemeHandler : NSObject,WKURLSchemeHandler {
     override init() {
         super.init()
         fileManager.delegate = self
-        activeAccount = DBManager.getAccountById(defaults.activeAccount!)
+        activeAccount = DBManager.getActiveAccount()
         fileManager.myAccount = activeAccount
     }
     

--- a/iOS-Email-Client/Controllers/ComposeViewController.swift
+++ b/iOS-Email-Client/Controllers/ComposeViewController.swift
@@ -120,8 +120,7 @@ class ComposeViewController: UIViewController {
         let textField = UITextField.appearance(whenContainedInInstancesOf: [CLTokenInputView.self])
         textField.font = Font.regular.size(14)
         
-        let defaults = CriptextDefaults()
-        activeAccount = DBManager.getAccountById(defaults.activeAccount!)
+        activeAccount = DBManager.getActiveAccount()
         fileManager.myAccount = activeAccount
         
         let sendImage = Icon.send.image?.tint(with: .white)

--- a/iOS-Email-Client/Controllers/CustomPasscodeViewController.swift
+++ b/iOS-Email-Client/Controllers/CustomPasscodeViewController.swift
@@ -58,8 +58,7 @@ class CustomPasscodeViewController: PasscodeLockViewController {
             return
         }
         let defaults = CriptextDefaults()
-        guard let accountId = defaults.activeAccount,
-            let account = SharedDB.getAccountById(accountId) else {
+        guard let account = SharedDB.getActiveAccount() else {
                 return
         }
         forceOut(account: account, manually: false, message: String.localize("MAX_PIN_ACCOUNT_DELETE"))
@@ -95,8 +94,7 @@ class CustomPasscodeViewController: PasscodeLockViewController {
     
     func confirmLogout(){
         let defaults = CriptextDefaults()
-        guard let accountId = defaults.activeAccount,
-            let account = SharedDB.getAccountById(accountId) else {
+        guard let account = SharedDB.getActiveAccount() else {
             self.showAlert(String.localize("SIGNOUT_ERROR"), message: String.localize("RESTART_APP"), style: .alert)
             return
         }

--- a/iOS-Email-Client/Controllers/InboxViewController.swift
+++ b/iOS-Email-Client/Controllers/InboxViewController.swift
@@ -1999,10 +1999,8 @@ extension InboxViewController {
     
     func swapAccount(_ account: Account) {
         loadViewIfNeeded()
-        let defaults = CriptextDefaults()
         DBManager.swapAccount(current: self.myAccount, active: account)
         self.myAccount = account
-        defaults.activeAccount = account.compoundKey
         WebSocketManager.sharedInstance.connect(accounts: [account])
         self.invalidateObservers()
         self.swapMailbox(labelId: mailboxData.selectedLabel, sender: nil, force: true)

--- a/iOS-Email-Client/Controllers/Login/ConnectDeviceViewController.swift
+++ b/iOS-Email-Client/Controllers/Login/ConnectDeviceViewController.swift
@@ -98,7 +98,7 @@ class ConnectDeviceViewController: UIViewController{
             dismiss(animated: true, completion: nil)
             return
         }
-        goToMailbox(myAccount.compoundKey)
+        goToMailbox(myAccount)
     }
     
     func cleanData(){
@@ -196,7 +196,7 @@ class ConnectDeviceViewController: UIViewController{
                 if self.multipleAccount {
                     self.goBackToMailbox(account: myAccount)
                 } else {
-                    self.goToMailbox(myAccount.compoundKey)
+                    self.goToMailbox(myAccount)
                 }
                 self.registerFirebaseToken(jwt: myAccount.jwt)
             }
@@ -219,7 +219,6 @@ class ConnectDeviceViewController: UIViewController{
         DBManager.store([myContact], account: myAccount)
         DBManager.createSystemLabels()
         let defaults = CriptextDefaults()
-        defaults.activeAccount = myAccount.compoundKey
         defaults.welcomeTour = true
     }
     
@@ -233,7 +232,7 @@ class ConnectDeviceViewController: UIViewController{
         delegate.swapAccount(account: account)
     }
     
-    func goToMailbox(_ activeAccount: String){
+    func goToMailbox(_ activeAccount: Account){
         self.socket?.close()
         guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
             return

--- a/iOS-Email-Client/Controllers/Login/CreatingAccountViewController.swift
+++ b/iOS-Email-Client/Controllers/Login/CreatingAccountViewController.swift
@@ -175,7 +175,6 @@ class CreatingAccountViewController: UIViewController{
         myContact.email = "\(myAccount.username)\(Env.domain)"
         DBManager.store([myContact], account: myAccount)
         let defaults = CriptextDefaults()
-        defaults.activeAccount = myAccount.compoundKey
         if signupData.deviceId != 1 {
             defaults.welcomeTour = true
         }
@@ -185,7 +184,7 @@ class CreatingAccountViewController: UIViewController{
             if self.multipleAccount {
                 self.goBackToMailbox(account: myAccount, showRestore: !hasEmails)
             } else {
-                self.goToMailbox(myAccount.compoundKey, showRestore: !hasEmails)
+                self.goToMailbox(myAccount, showRestore: !hasEmails)
             }
         }
     }
@@ -212,7 +211,7 @@ class CreatingAccountViewController: UIViewController{
         self.present(alert, animated: true, completion: nil)
     }
     
-    func goToMailbox(_ activeAccount: String, showRestore: Bool){
+    func goToMailbox(_ activeAccount: Account, showRestore: Bool){
         guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
             return
         }

--- a/iOS-Email-Client/Controllers/MenuViewController.swift
+++ b/iOS-Email-Client/Controllers/MenuViewController.swift
@@ -124,9 +124,10 @@ class MenuViewController: UIViewController{
         nameLabel.text = myAccount.name
         usernameLabel.text = myAccount.email
         avatarImage.sd_setImage(with: URL(string: "\(Env.apiURL)/user/avatar/\(myAccount.domain ?? Env.plainDomain)/\(myAccount.username)"), placeholderImage: nil, options: [SDWebImageOptions.continueInBackground, SDWebImageOptions.lowPriority]) { (image, error, cacheType, url) in
-            if error != nil {
+            if error != nil,
+                !myAccount.isInvalidated {
                 self.avatarImage.setImageWith(myAccount.name, color: colorByName(name: myAccount.name), circular: true, fontName: "NunitoSans-Regular")
-            }else{
+            } else {
                 self.avatarImage.contentMode = .scaleAspectFill
                 self.avatarImage.layer.masksToBounds = false
                 self.avatarImage.layer.cornerRadius = self.avatarImage.frame.size.width / 2
@@ -230,7 +231,9 @@ class MenuViewController: UIViewController{
                 weakSelf.accountsTableView.reloadData()
                 weakSelf.accountsCollectionView.reloadData()
             }
-            weakSelf.mailboxVC.circleBadgeView.isHidden = !weakSelf.menuData.accountBadge.contains(where: {$0.value > 0})
+            if (weakSelf.mailboxVC != nil) {
+                weakSelf.mailboxVC.circleBadgeView.isHidden = !weakSelf.menuData.accountBadge.contains(where: {$0.value > 0})
+            }
         }
     }
     

--- a/iOS-Email-Client/Libs/CriptextDefaults.swift
+++ b/iOS-Email-Client/Libs/CriptextDefaults.swift
@@ -85,20 +85,6 @@ class CriptextDefaults {
     }
     
     //SHARED DEFAULTS
-    
-    var hasActiveAccount: Bool {
-        return groupDefaults.string(forKey: "activeAccount") != nil
-    }
-    
-    var activeAccount: String? {
-        get {
-            return groupDefaults.string(forKey: "activeAccount")
-        }
-        set (value) {
-            groupDefaults.set(value, forKey: "activeAccount")
-        }
-    }
-    
     var hasPIN : Bool {
         return groupDefaults.string(forKey: PIN.lock.rawValue) != nil
     }
@@ -214,16 +200,12 @@ class CriptextDefaults {
 }
 
 extension CriptextDefaults {
-    func removeActiveAccount(){
-        groupDefaults.removeObject(forKey: "activeAccount")
-    }
     
     func removePasscode() {
         groupDefaults.removeObject(forKey: PIN.lock.rawValue)
     }
     
     func removeConfig() {
-        groupDefaults.removeObject(forKey: "activeAccount")
         groupDefaults.removeObject(forKey: PIN.lock.rawValue)
         groupDefaults.removeObject(forKey: PIN.fingerprint.rawValue)
         groupDefaults.removeObject(forKey: PIN.faceid.rawValue)
@@ -240,11 +222,6 @@ extension CriptextDefaults {
     }
     
     func migrate(){
-        if let activeAccount = defaults.string(forKey: "activeAccount"),
-            groupDefaults.string(forKey: "activeAccount") == nil {
-            defaults.removeObject(forKey: "activeAccount")
-            groupDefaults.setValue(activeAccount, forKey: "activeAccount")
-        }
         if let pin = defaults.string(forKey: PIN.lock.rawValue) {
             let fingerprint = defaults.bool(forKey: PIN.fingerprint.rawValue)
             let faceid = defaults.bool(forKey: PIN.faceid.rawValue)

--- a/iOS-Email-Client/Managers/DBManager.swift
+++ b/iOS-Email-Client/Managers/DBManager.swift
@@ -71,6 +71,11 @@ class DBManager: SharedDB {
         }
     }
     
+    class func getActiveAccounts() -> Results<Account> {
+        let realm = try! Realm()
+        return realm.objects(Account.self).filter("isActive == true AND isLoggedIn == true")
+    }
+    
     class func getInactiveAccounts() -> Results<Account> {
         let realm = try! Realm()
         return realm.objects(Account.self).filter("isActive == false AND isLoggedIn == true")

--- a/iOS-Email-Client/Managers/DBManager.swift
+++ b/iOS-Email-Client/Managers/DBManager.swift
@@ -71,11 +71,6 @@ class DBManager: SharedDB {
         }
     }
     
-    class func getActiveAccounts() -> Results<Account> {
-        let realm = try! Realm()
-        return realm.objects(Account.self).filter("isActive == true AND isLoggedIn == true")
-    }
-    
     class func getInactiveAccounts() -> Results<Account> {
         let realm = try! Realm()
         return realm.objects(Account.self).filter("isActive == false AND isLoggedIn == true")

--- a/iOS-Email-Client/Shared/SharedDB.swift
+++ b/iOS-Email-Client/Shared/SharedDB.swift
@@ -39,6 +39,11 @@ class SharedDB {
         return realm.objects(Account.self).first
     }
     
+    class func getActiveAccount() -> Account? {
+        let realm = try! Realm()
+        return realm.objects(Account.self).filter("isActive == true AND isLoggedIn == true").first
+    }
+    
     class func getAccountById(_ id: String) -> Account? {
         let realm = try? Realm()
         
@@ -180,7 +185,7 @@ class SharedDB {
         let MAX_ADDRESS_LENGTH = 320
         let query = text.count > 320 ? String(text.prefix(MAX_ADDRESS_LENGTH)) : text
         
-        let predicate = NSPredicate(format: "email contains[c] '\(query)' OR displayName contains[c] '\(query)'")
+        let predicate = NSPredicate(format: "email contains[c] %@ OR displayName contains[c] %@", query, query)
         let results = realm.objects(Contact.self).filter(predicate).sorted(byKeyPath: "score", ascending: false)
         
         return Array(results)

--- a/iOS-Email-Client/de.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/de.lproj/CriptextLocalizable.strings
@@ -428,6 +428,7 @@
 "CONTACT_SUPPORT" = "Kontaktieren Sie den Support";
 "SYNC_WARNING_MESSAGE" = "Verlassen Sie die App nicht und schalten Sie Ihren Bildschirm nicht aus, während dieser Prozess läuft.";
 "FILE_NOT_FOUND" = "Datei %s nicht gefunden";
+"FILE_NOT_MERGED" = "Unable to process File %s";
 "CONTENT_UNENCRYPTED" = "Inhalt unverschlüsselt";
 "FOOTER" = "Zeige \"Gesendet mit Criptext\".";
 "MARK_FROM_HERE" = "Von hier aus als ungelesen markieren";

--- a/iOS-Email-Client/en.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/en.lproj/CriptextLocalizable.strings
@@ -428,6 +428,7 @@
 "CONTACT_SUPPORT" = "Contact Support";
 "SYNC_WARNING_MESSAGE" = "Do not leave the app or turn off your screen while this process is happening";
 "FILE_NOT_FOUND" = "File %s not found";
+"FILE_NOT_MERGED" = "Unable to process File %s";
 "CONTENT_UNENCRYPTED" = "Content Unencrypted";
 "FOOTER" = "Show “Sent with Criptext”";
 "MARK_FROM_HERE" = "Mark as Unread from here";

--- a/iOS-Email-Client/es.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/es.lproj/CriptextLocalizable.strings
@@ -428,6 +428,7 @@
 "CONTACT_SUPPORT" = "Contáctanos";
 "SYNC_WARNING_MESSAGE" = "No cierres la aplicación o apagues la pantalla hasta que termine este proceso";
 "FILE_NOT_FOUND" = "El archivo %s no encontrado";
+"FILE_NOT_MERGED" = "No fue posible procesar el archivo %s";
 "CONTENT_UNENCRYPTED" = "No se pudo decriptar el contenido";
 "FOOTER" = "Mostrar “Enviado con Criptext”";
 "MARK_FROM_HERE" = "Marcar como no leído desde aquí";

--- a/iOS-Email-Client/fr.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/fr.lproj/CriptextLocalizable.strings
@@ -428,6 +428,7 @@
 "CONTACT_SUPPORT" = "Contacter le support";
 "SYNC_WARNING_MESSAGE" = "Ne quittez pas l'application et n'éteignez pas votre écran pendant ce processus";
 "FILE_NOT_FOUND" = "Fichier %s non trouvé";
+"FILE_NOT_MERGED" = "Unable to process File %s";
 "CONTENT_UNENCRYPTED" = "Contenu non crypté";
 "FOOTER" = "Montrer “Envoyé avec Criptext”";
 "MARK_FROM_HERE" = "Marquer comme non lu à partir d'ici";

--- a/iOS-Email-Client/ru.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/ru.lproj/CriptextLocalizable.strings
@@ -428,6 +428,7 @@
 "CONTACT_SUPPORT" = "Связаться со службой поддержки";
 "SYNC_WARNING_MESSAGE" = "Не покидайте приложение и не выключайте экран во время этого процесса";
 "FILE_NOT_FOUND" = "Файл %s не найден";
+"FILE_NOT_MERGED" = "Unable to process File %s";
 "CONTENT_UNENCRYPTED" = "Содержимое незашифрованное";
 "FOOTER" = "Шоу «Отправлено с криптекстом»";
 "MARK_FROM_HERE" = "Отметить как непрочитанное отсюда";

--- a/iOS-Email-ClientTests/Cases/ComposerViewControllerTests.swift
+++ b/iOS-Email-ClientTests/Cases/ComposerViewControllerTests.swift
@@ -21,17 +21,15 @@ class ComposerViewControllerTests: XCTestCase {
         account.username = "myself"
         account.deviceId = 1
         account.jwt = "<test_jwt>"
+        account.isActive = true
+        account.isLoggedIn = true
         account.buildCompoundKey()
         DBManager.store(account)
         self.account = account
-        let defaults = CriptextDefaults()
-        defaults.activeAccount = account.compoundKey
     }
     
     override func tearDown() {
-        super.tearDown()
-        
-        CriptextDefaults().removeConfig()
+        super.tearDown()        
         DBManager.destroy()
     }
     

--- a/iOS-Email-ClientTests/Cases/CreateCustomJSONFileTests.swift
+++ b/iOS-Email-ClientTests/Cases/CreateCustomJSONFileTests.swift
@@ -34,8 +34,6 @@ class CreateCustomJSONFileTests: XCTestCase {
         super.setUp()
         
         self.account = DBFactory.createAndStoreAccount(username: "test", deviceId: 1, name: "Test")
-        let defaults = CriptextDefaults()
-        defaults.activeAccount = account.compoundKey
         
         let newLabel = Label("Test 1")
         newLabel.id = 1
@@ -95,8 +93,6 @@ class CreateCustomJSONFileTests: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        let defaults = CriptextDefaults()
-        defaults.removeConfig()
         DBManager.destroy()
     }
     

--- a/iOS-Email-ClientTests/Supporting Files/DBFactory.swift
+++ b/iOS-Email-ClientTests/Supporting Files/DBFactory.swift
@@ -17,6 +17,8 @@ class DBFactory {
         newAccount.username = username
         newAccount.deviceId = deviceId
         newAccount.buildCompoundKey()
+        newAccount.isActive = true
+        newAccount.isLoggedIn = true
         DBManager.store(newAccount)
         
         return newAccount


### PR DESCRIPTION
- Removing stored active account in `defaults`. Now verifying active account by column `active` when app starts
- Extension `Shared Extension` name set
- `MenuViewController` avatar image and badge update crash handle
- File merge process crash handle
- `getContacts` query crash handle