### PR TITLE
Sent to Alias and Delete Alias Days Left

### DIFF
--- a/iOS-Email-Client/AsyncTasks/SendMailAsyncTask.swift
+++ b/iOS-Email-Client/AsyncTasks/SendMailAsyncTask.swift
@@ -427,13 +427,13 @@ class SendMailAsyncTask {
                         ] as [String : Any])
                     continue
                 }
-                let aliasUsername = username
                 let originalUsername = recipientId.contains("@") ? recipientId.split(separator: "@").first!.description : recipientId
                 criptextEmailData.append([
                     "type": contactType,
                     "username": originalUsername,
                     "domain": domainToSend,
-                    "alias": aliasUsername,
+                    "aliasUsername": username,
+                    "aliasDomain": domain,
                     "emails": emailsData
                     ] as [String : Any])
             }

--- a/iOS-Email-Client/Controllers/Login/CreatingAccountViewController.swift
+++ b/iOS-Email-Client/Controllers/Login/CreatingAccountViewController.swift
@@ -119,6 +119,7 @@ class CreatingAccountViewController: UIViewController{
         let domain = CustomDomain()
         domain.name = domainName
         domain.validated = domainVerified == 1 ? true : false
+        domain.account = account
         
         let aliasesArray: [Alias] = aliases.map({Alias.aliasFromDictionary(aliasData: $0, domainName: domainName, account: account)})
         

--- a/iOS-Email-Client/Controllers/RemoveAliasUIPopover.swift
+++ b/iOS-Email-Client/Controllers/RemoveAliasUIPopover.swift
@@ -72,8 +72,8 @@ class RemoveAliasUIPopover: BaseUIPopover {
                 self.logout(account: self.myAccount)
                 return
             }
-            if case .BadRequest = responseData {
-                self.setFailContent(message: String.localize("ALIASES_DELETE_ERROR_UNABLE"))
+            if case let .PreConditionRequired(daysLeft) = responseData {
+                self.setFailContent(message: String.localize("ALIASES_DELETE_ERROR_UNABLE", arguments: daysLeft.description))
                 return
             }
             guard case .Success = responseData else {

--- a/iOS-Email-Client/Controllers/SettingsGeneralViewController.swift
+++ b/iOS-Email-Client/Controllers/SettingsGeneralViewController.swift
@@ -227,6 +227,7 @@ class SettingsGeneralViewController: UIViewController{
         let domain = CustomDomain()
         domain.name = domainName
         domain.validated = domainVerified == 1 ? true : false
+        domain.account = account
         
         let aliasesArray: [Alias] = aliases.map({Alias.aliasFromDictionary(aliasData: $0, domainName: domainName, account: account)})
         

--- a/iOS-Email-Client/Managers/APIManager.swift
+++ b/iOS-Email-Client/Managers/APIManager.swift
@@ -1070,7 +1070,7 @@ class APIManager: SharedAPI {
         let params = [
             "addressId": rowId
             ] as [String: Any]
-        Alamofire.request(url, method: .delete, parameters: params, encoding: JSONEncoding.default, headers: headers).responseString { (response) in
+        Alamofire.request(url, method: .delete, parameters: params, encoding: JSONEncoding.default, headers: headers).responseJSON { (response) in
             let responseData = handleResponse(response, satisfy: .success)
             completion(responseData)
         }

--- a/iOS-Email-Client/Model/ResponseData.swift
+++ b/iOS-Email-Client/Model/ResponseData.swift
@@ -27,6 +27,7 @@ enum ResponseData {
     case EntityTooLarge(Int64)
     case TooManyRequests(Int64)
     case ServerError
+    case PreConditionRequired(Int)
     case PreConditionFail
     case EnterpriseSuspended
 }

--- a/iOS-Email-Client/Shared/SharedAPI.swift
+++ b/iOS-Email-Client/Shared/SharedAPI.swift
@@ -34,6 +34,7 @@ class SharedAPI {
         case authPending = 491
         case authDenied = 493
         case tooManyDevices = 439
+        case preConditionRequired = 428
         case tooManyRequests = 429
         case preConditionFail = 412
         case entityTooLarge = 413
@@ -84,6 +85,12 @@ class SharedAPI {
             return .Conflicts
         case .success, .successAndRepeat, .successAccepted, .successNoContent, .notModified:
             break
+        case .preConditionRequired:
+            guard let resultObj = responseRequest.result.value as? [String: Any],
+                let daysLeft = resultObj["daysLeft"] as? Int else {
+                return .Error(CriptextError(message: responseRequest.result.description))
+            }
+            return .PreConditionRequired(daysLeft)
         case .preConditionFail:
             return .PreConditionFail
         case .enterpriseSuspended:

--- a/iOS-Email-Client/Shared/SharedDB.swift
+++ b/iOS-Email-Client/Shared/SharedDB.swift
@@ -550,6 +550,6 @@ class SharedDB {
     
     class func getAlias(username: String, domain: String?, account: Account) -> Alias? {
         let realm = try! Realm()
-        return realm.objects(Alias.self).filter("name == %@ AND domainName == %@ AND account.compoundKey == %@", username, domain, account.compoundKey).first
+        return realm.objects(Alias.self).filter("name == %@ AND domain == %@ AND account.compoundKey == %@", username, domain, account.compoundKey).first
     }
 }

--- a/iOS-Email-Client/de.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/de.lproj/CriptextLocalizable.strings
@@ -460,7 +460,7 @@
 "ALIASES_DELETE" = "Delete Alias";
 "ALIASES_DELETE_DESC" = "If you delete this Alias your emails will remain intact, but you will no longer be able to send or receive emails under that address.\n\nAre you sure you want to delete %@?";
 "ALIASES_DELETE_ERROR_TITLE" = "Oops";
-"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.";
+"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.\n\nDays remaining: %@";
 "ALIASES_DELETE_ERROR_UNKNOWN" = "Unknown Server Error. Please try again";
 "NEXT" = "Next";
 "DELETE_DOMAIN" = "Delete Domain";

--- a/iOS-Email-Client/en.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/en.lproj/CriptextLocalizable.strings
@@ -461,7 +461,7 @@
 "ALIASES_DELETE" = "Delete Alias";
 "ALIASES_DELETE_DESC" = "If you delete this Alias your emails will remain intact, but you will no longer be able to send or receive emails under that address.\n\nAre you sure you want to delete %@?";
 "ALIASES_DELETE_ERROR_TITLE" = "Oops";
-"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.";
+"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.\n\nDays remaining: %@";
 "ALIASES_DELETE_ERROR_UNKNOWN" = "Unknown Server Error. Please try again";
 "NEXT" = "Next";
 "DELETE_DOMAIN" = "Delete Domain";

--- a/iOS-Email-Client/es.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/es.lproj/CriptextLocalizable.strings
@@ -460,7 +460,7 @@
 "ALIASES_DELETE" = "Eliminar Alias";
 "ALIASES_DELETE_DESC" = "Si eliminas este alias tus correos permanecerán intactos, pero no podrás enviar ni recibir correos a esa dirección.\n\nEstás seguro que quieres eliminar %@?";
 "ALIASES_DELETE_ERROR_TITLE" = "Ups...";
-"ALIASES_DELETE_ERROR_UNABLE" = "Aliases que terminan en @criptext.com no pueden ser eliminados los primeros 15 días desde su creación.";
+"ALIASES_DELETE_ERROR_UNABLE" = "Aliases que terminan en @criptext.com no pueden ser eliminados los primeros 15 días desde su creación.\n\nDías restantes: %@";
 "ALIASES_DELETE_ERROR_UNKNOWN" = "Error desconocido. Por favor intenta de nuevo";
 "NEXT" = "Siguiente";
 "DELETE_DOMAIN" = "Remover Dominio";

--- a/iOS-Email-Client/fr.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/fr.lproj/CriptextLocalizable.strings
@@ -460,7 +460,7 @@
 "ALIASES_DELETE" = "Delete Alias";
 "ALIASES_DELETE_DESC" = "If you delete this Alias your emails will remain intact, but you will no longer be able to send or receive emails under that address.\n\nAre you sure you want to delete %@?";
 "ALIASES_DELETE_ERROR_TITLE" = "Oops";
-"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.";
+"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.\n\nDays remaining: %@";
 "ALIASES_DELETE_ERROR_UNKNOWN" = "Unknown Server Error. Please try again";
 "NEXT" = "Next";
 "DELETE_DOMAIN" = "Delete Domain";

--- a/iOS-Email-Client/ru.lproj/CriptextLocalizable.strings
+++ b/iOS-Email-Client/ru.lproj/CriptextLocalizable.strings
@@ -460,7 +460,7 @@
 "ALIASES_DELETE" = "Delete Alias";
 "ALIASES_DELETE_DESC" = "If you delete this Alias your emails will remain intact, but you will no longer be able to send or receive emails under that address.\n\nAre you sure you want to delete %@?";
 "ALIASES_DELETE_ERROR_TITLE" = "Oops";
-"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.";
+"ALIASES_DELETE_ERROR_UNABLE" = "Aliases ending in @criptext.com cannot be deleted within 15 days from the day they were created.\n\nDays remaining: %@";
 "ALIASES_DELETE_ERROR_UNKNOWN" = "Unknown Server Error. Please try again";
 "NEXT" = "Next";
 "DELETE_DOMAIN" = "Delete Domain";

--- a/iOS-Email-ClientTests/Supporting Files/APIManagerSpy.swift
+++ b/iOS-Email-ClientTests/Supporting Files/APIManagerSpy.swift
@@ -19,7 +19,8 @@ class APIManagerSpy: APIManager {
         completion(ResponseData.SuccessDictionary([
             "keyBundles": [[String: Any]](),
             "blacklistedKnownDevices": [[String: Any]](),
-            "guestDomains": [String]()
+            "guestDomains": [String](),
+            "addresses": [[String: Any]]()
         ]))
     }
     

--- a/iOS-Email-ClientTests/Supporting Files/FindKeybundleSpyApiManager.swift
+++ b/iOS-Email-ClientTests/Supporting Files/FindKeybundleSpyApiManager.swift
@@ -19,7 +19,8 @@ class FindKeybundleSpyApiManager: APIManager {
         completion(ResponseData.SuccessDictionary([
             "keyBundles": [[String: Any]](),
             "blacklistedKnownDevices": [[String: Any]](),
-            "guestDomains": [String]()
+            "guestDomains": [String](),
+            "addresses": [[String: Any]]()
             ]))
         handleExpectation(params: params)
     }


### PR DESCRIPTION
- Added `aliasUsername` and `aliasDomain` when sending an email to an alias
- Delete alias handles event `428`, shows remaining days to delete